### PR TITLE
Updated documentation + blocklist location changed

### DIFF
--- a/README
+++ b/README
@@ -176,7 +176,7 @@ incremental update; make a copy if you need to add fancier abilities to it.
 
 c. [optional (kind of)] image path (-g)
 
-This is where pigmap expects to find either a copy of your tileset (terrain.png, etc.), or a copy of
+This is where pigmap expects to find either a copy of your textures (texture/ folder of your minecraft.jar etc.), or a copy of
 blocks-B.png (substituting the actual numeric value of B; see below for definition of B), a
 pigmap-generated file that contains the isometric renderings of each block.  These files are not
 optional, but the -g parameter itself may be omitted, in which case "." is used as the image path.
@@ -195,15 +195,8 @@ This means that pigmap will need your tileset the first time it runs, so it can 
 subsequent runs will use the existing blocks-B.png, which can be manually edited if insufficiently
 pretty, or for special effects, etc.
 
-The following images are required to generate blocks-B.png:
--terrain.png, chest.png, largechest.png, enderchest.png: these files come from your tileset
-  or minecraft.jar
--fire.png, endportal.png: these files are included with pigmap
-All of these must be RGBA png files (not just RGB).
-
-High-res tilesets are supported.  The textures in terrain.png, fire.png, and endportal.png can be
-any size, as long as they remain square.  The textures in the chest pngs can be scaled up, but their
-size must be an integer multiple of the original size.
+The generate blocks-B.pngi, extract the item/ and textures/ folder of your minecraft.jar into the folder you have specified.
+All of these must be RGBA png files (not just RGB). So check the alpha channels, if one file is not recognized. From minecraft version 1.5 it is known that the lava.png is missing an alpha channel. You can simply add one by using tools like GIMP.
 
 d. [optional] number of threads (-t)
 

--- a/blockimages.cpp
+++ b/blockimages.cpp
@@ -67,8 +67,8 @@ bool BlockImages::create(int B, const string& imgpath)
 
 	// 1.5
 	// Block mapping is specified in a separate list, pointing to textures listed in another file
-	string blocktexturesfile = "blocktextures.list";
-	string blockdescriptorfile = "blockdescriptor.list";
+	string blocktexturesfile = imgpath + "/blocktextures.list";
+	string blockdescriptorfile = imgpath + "/blockdescriptor.list";
 	
 	ifstream texturelist(blocktexturesfile.c_str());
 	ifstream descriptorlist(blockdescriptorfile.c_str());
@@ -2363,7 +2363,7 @@ bool BlockImages::construct(int B, ifstream& texturelist, ifstream& descriptorli
 		{
 			if(!iblockimage.readPNG(blocktexturespath + "/" + textureDirectives[1])) // texture read error
 			{
-				cerr << "[texture.list]" << textureiterator + 1 << " - " << blocktexturespath << "/" << textureDirectives[1] << " is missing or invalid" << endl;
+				cerr << "[blocktexture.list]" << textureiterator + 1 << " - " << blocktexturespath << "/" << textureDirectives[1] << " is missing or invalid (check, if it has an alpha channel!)" << endl;
 				missingtextures = true;
 			}
 			else // process texture

--- a/pigmap.cpp
+++ b/pigmap.cpp
@@ -840,7 +840,7 @@ bool validateParamsFull(const string& inputpath, const string& outputpath, const
 	//  insanely large map to see any benefit to having that many...)
 	if (threads < 1 || threads > 64)
 	{
-		cerr << "-h must be in range 1-64" << endl;
+		cerr << "-t must be in range 1-64" << endl;
 		return false;
 	}
 
@@ -924,7 +924,7 @@ bool validateParamsIncremental(const string& inputpath, const string& outputpath
 	//  insanely large map to see any benefit to having that many...)
 	if (threads < 1 || threads > 64)
 	{
-		cerr << "-h must be in range 1-64" << endl;
+		cerr << "-t must be in range 1-64" << endl;
 		return false;
 	}
 
@@ -966,7 +966,7 @@ bool validateParamsTest(const string& inputpath, const string& outputpath, const
 	//  insanely large map to see any benefit to having that many...)
 	if (threads < 1 || threads > 64)
 	{
-		cerr << "-h must be in range 1-64" << endl;
+		cerr << "-t must be in range 1-64" << endl;
 		return false;
 	}
 
@@ -1083,7 +1083,7 @@ int main(int argc, char **argv)
 				cerr << "PigMap " << endl
                                      << "-i <path> minecraft world input path. This should be the base of the world" << endl
                                      << "-o <path> output path. This is the diretory to put the html file in" << endl
-                                     << "-g <path> image path. This is where to find the minecraft terrain.png and also to output the cached blocks." << endl
+                                     << "-g <path> image path. This is where to find the *.list files, minecraft textures and also to output the cached blocks." << endl
                                      << "-c [filename] file containing chunks to render" << endl
                                      << "-r [filename] file containing regions to render" << endl
                                      << "-f [format] rendering output format - png,jpg or both" << endl
@@ -1091,7 +1091,7 @@ int main(int argc, char **argv)
                                      << "-Y <int> maximum Y value" << endl
                                      << "-y <int> minimum Y value" << endl
                                      << "-Z <int> (base zoom)?" << endl
-                                     << "-h <int> threads to use for rendering" << endl
+                                     << "-t <int> threads to use for rendering" << endl
                                      << "-B <int> Block size - size in pixels of each minecraft block (2-16)!" << endl
                                      << "-T <int> Tile Size Division. (2-16)" << endl
                                      << "-Z <int> Map zoom levels (0-30)" << endl


### PR DESCRIPTION
Hi,

first many thanks for providing an update for Minecraft 1.5.

I have made the respective changes to the documentation. I hope I did not forget something. I also added a hint that it may be required to add alpha channels to some minecraft textures in order to work.

The other thing is, that I changed the path where the *.list files are expected. Currently it's the working directory. I changed it to be the image directory specified with -g. I think this is more appropiate for the use in shell scripts where the working directory might be something different.

Cheers,
UniversE
