### PR TITLE
Texture names now apply to 1.7.2

### DIFF
--- a/blockdescriptor.list
+++ b/blockdescriptor.list
@@ -220,4 +220,4 @@
 173 SOLID coal_block
 # 1.7
 174 SOLID ice_packed #packed ice
-175 ITEMDATATALLORIENTED doublePlant_sunflower_top doublePlant_sunflower_bottom doublePlant_syringa_top doublePlant_syringa_bottom doublePlant_grass_top doublePlant_grass_bottom doublePlant_fern_top doublePlant_fern_bottom doublePlant_rose_top doublePlant_rose_bottom doublePlant_paeonia_top doublePlant_paeonia_bottom #double flowers (sunflower / lilac / d. tall grass / large fern / rose bush / peony)
+175 ITEMDATATALLORIENTED double_plant_sunflower_top double_plant_sunflower_bottom double_plant_syringa_top double_plant_syringa_bottom double_plant_grass_top double_plant_grass_bottom double_plant_fern_top double_plant_fern_bottom double_plant_rose_top double_plant_rose_bottom double_plant_paeonia_top double_plant_paeonia_bottom #double flowers (sunflower / lilac / d. tall grass / large fern / rose bush / peony)

--- a/blocktextures.list
+++ b/blocktextures.list
@@ -124,20 +124,20 @@ door_iron_lower.png
 door_iron_upper.png
 door_wood_lower.png
 door_wood_upper.png
-/ doublePlant_fern_bottom.png DARKEN 0.6 0.95 0.3
-/ doublePlant_fern_top.png DARKEN 0.6 0.95 0.3
-/ doublePlant_grass_bottom.png DARKEN 0.6 0.95 0.3
-/ doublePlant_grass_top.png DARKEN 0.6 0.95 0.3
-doublePlant_paeonia_bottom.png
-doublePlant_paeonia_top.png
-doublePlant_rose_bottom.png
-doublePlant_rose_top.png
-#doublePlant_sunflower_back.png
-doublePlant_sunflower_bottom.png
-#doublePlant_sunflower_front.png
-/ doublePlant_sunflower_top.png OVERLAY doublePlant_sunflower_front.png
-doublePlant_syringa_bottom.png
-doublePlant_syringa_top.png
+/ double_plant_fern_bottom.png DARKEN 0.6 0.95 0.3
+/ double_plant_fern_top.png DARKEN 0.6 0.95 0.3
+/ double_plant_grass_bottom.png DARKEN 0.6 0.95 0.3
+/ double_plant_grass_top.png DARKEN 0.6 0.95 0.3
+double_plant_paeonia_bottom.png
+double_plant_paeonia_top.png
+double_plant_rose_bottom.png
+double_plant_rose_top.png
+#double_plant_sunflower_back.png
+double_plant_sunflower_bottom.png
+#double_plant_sunflower_front.png
+/ double_plant_sunflower_top.png OVERLAY double_plant_sunflower_front.png
+double_plant_syringa_bottom.png
+double_plant_syringa_top.png
 dragon_egg.png
 dropper_front_horizontal.png
 dropper_front_vertical.png


### PR DESCRIPTION
The doublePlants_\* textures are named double_plants_\* in 1.7.2.
